### PR TITLE
Enhanced GFF updating

### DIFF
--- a/ragtag_splitasm.py
+++ b/ragtag_splitasm.py
@@ -24,13 +24,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import os
 import re
 import sys
 import argparse
 
 import pysam
 
+from ragtag_correct import make_gff_interval_tree
+
 from ragtag_utilities.utilities import get_ragtag_version
+from ragtag_utilities.utilities import log
 from ragtag_utilities.AGPFile import AGPFile
 
 
@@ -39,6 +43,7 @@ def main():
     parser.add_argument("asm", metavar="<asm.fa>", default="", type=str, help="assembly fasta file (uncompressed or bgzipped)")
     parser.add_argument("-n", metavar="INT", type=int, default=0, help="minimum gap size [0]")
     parser.add_argument("-o", metavar="PATH", type=str, default="ragtag.splitasm.agp", help="output AGP file path [./ragtag.splitasm.agp]")
+    parser.add_argument("--gff", metavar="<features.gff>", type=str, default="", help="don't break sequences within gff intervals [null]")
 
     # Parse the command line arguments
     args = parser.parse_args()
@@ -50,7 +55,11 @@ def main():
     asm_fn = args.asm
     min_gap_size = args.n
     agp_fn = args.o
-
+    gff_file = args.gff
+    if gff_file:
+        gff_file = os.path.abspath(gff_file)
+        it = make_gff_interval_tree(gff_file)
+        log("INFO", "Avoiding breaks within GFF intervals")
     # Initialize the AGP file
     agp = AGPFile(agp_fn, mode="w")
     agp.add_pragma()
@@ -63,6 +72,19 @@ def main():
         seq = fai.fetch(header).upper()
         seq_len = fai.get_reference_length(header)
         gap_coords = [(i.start(), i.end()) for i in re.finditer(r'N+', seq) if i.end() - i.start() > min_gap_size]
+        # Remove coordinates overlapping gff features
+        if gff_file:
+            #non_gff_breaks = dict()
+            new_breaks = []
+            for gap in gap_coords:
+                if it[header][gap[0]] or it[header][gap[1]]:
+                    log("INFO", "Avoiding breaking %s between %d-%d. This point intersects a feature in the gff file."
+                                % (header, gap[0], gap[1]))
+                else:
+                    new_breaks.append(gap)
+            if new_breaks:
+                #non_gff_breaks[header] = new_breaks
+                gap_coords = new_breaks
 
         if not gap_coords:
             new_header = "seq{0:08}".format(new_header_idx)

--- a/ragtag_update_gff.py
+++ b/ragtag_update_gff.py
@@ -28,7 +28,6 @@ import os
 import sys
 import argparse
 from collections import defaultdict
-import warnings
 import re
 
 from intervaltree import IntervalTree
@@ -87,10 +86,10 @@ def sub_update(gff_file, agp_file, is_split):
 
                 ovlps = trans[h][s:e]
                 if len(ovlps) > 1:
-                    warnings.warn("%s:%d-%d in the gff file overlaps two sub sequences in the placement file. Make sure to run 'correct' or 'splitasm' with '--gff'" % (h, s, e))
                     #raise ValueError(
                     #    "%s:%d-%d in the gff file overlaps two sub-sequences in the placement file. Make sure to run 'ragtag.py correct' with '--gff'" % (h, s, e)
                     #)
+                    log("WARNING", "%s:%d-%d in the gff file overlaps two sub sequences in the placement file. Skipping %s. Make sure to run 'correct' or 'splitasm' with '--gff'" % (h, s, e, feat_id))
                     if feat_id:
                         ovlp_ids.append(feat_id)
                 if len(ovlps) < 1:
@@ -119,7 +118,7 @@ def sub_update(gff_file, agp_file, is_split):
                     print("\t".join(fields))
 
 
-def sup_update(gff_file, agp_file, is_split):
+def sup_update(gff_file, agp_file):
     # Make a dictionary associating each original sequence with the destination sequence
     trans = {}
     strands = {}
@@ -167,7 +166,7 @@ def sup_update(gff_file, agp_file, is_split):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Update gff intervals from `correct`, `scaffold`, or `splitasm` given a RagTag AGP file", usage="ragtag.py updategff [-c] <genes.gff> <ragtag.agp>")
+    parser = argparse.ArgumentParser(description="Update gff intervals from given a RagTag AGP file", usage="ragtag.py updategff [-c] <genes.gff> <ragtag.agp>")
     parser.add_argument("gff", nargs='?', default="", metavar="<genes.gff>", type=str, help="gff file")
     parser.add_argument("agp", nargs='?', default="", metavar="<ragtag.*.agp>", type=str, help="agp file")
     parser.add_argument("-c", action="store_true", default=False, help="update for misassembly correction (ragtag.correction.agp)")


### PR DESCRIPTION
* Added `--gff` option to `splitasm`, allowing user to avoid splitting the assembly at gaps that intersect features in a gff. Gff parsing conventions match (and import a function from) the `ragtag_correct.py`
* Added option `-s` to `ragtag_update_gff.py` that works similar to `-c` for the case of correcting a gff that has been split by `splitasm`. When enabled, it handles gaps in the AGP by simply skipping any gff feature that spans multiple sequences, logging a warning to the screen. Any child features of a parent overlapping a gap will also be skipped to prevent output of orphan features, e.g a stop codon after the gap.

Outside of feature enhancements, all current behavior and functionality is exactly preserved.